### PR TITLE
Remove use of @StateObject for MIDIHelper() in “EndpointPickers” and “EventParsing” Example apps

### DIFF
--- a/Examples/iOS SwiftUI/EndpointPickers/EndpointPickers/EndpointPickersApp.swift
+++ b/Examples/iOS SwiftUI/EndpointPickers/EndpointPickers/EndpointPickersApp.swift
@@ -15,7 +15,7 @@ struct EndpointPickersApp: App {
         manufacturer: "MyCompany"
     )
     
-    @StateObject var midiHelper = MIDIHelper()
+    var midiHelper = MIDIHelper()
     
     @State var midiInSelectedID: MIDIIdentifier = .invalidMIDIIdentifier
     @State var midiInSelectedDisplayName: String = "None"

--- a/Examples/iOS SwiftUI/EventParsing/EventParsing/EventParsingApp.swift
+++ b/Examples/iOS SwiftUI/EventParsing/EventParsing/EventParsingApp.swift
@@ -15,7 +15,7 @@ struct EventParsingApp: App {
         manufacturer: "MyCompany"
     )
     
-    @StateObject var midiHelper = MIDIHelper()
+    var midiHelper = MIDIHelper()
     
     init() {
         midiHelper.midiManager = midiManager

--- a/Examples/macOS SwiftUI/EndpointPickers/EndpointPickers/EndpointPickersApp.swift
+++ b/Examples/macOS SwiftUI/EndpointPickers/EndpointPickers/EndpointPickersApp.swift
@@ -15,7 +15,7 @@ struct EndpointPickersApp: App {
         manufacturer: "MyCompany"
     )
     
-    @StateObject var midiHelper = MIDIHelper()
+    var midiHelper = MIDIHelper()
     
     @State var midiInSelectedID: MIDIIdentifier = .invalidMIDIIdentifier
     @State var midiInSelectedDisplayName: String = "None"

--- a/Examples/macOS SwiftUI/EventParsing/EventParsing/EventParsingApp.swift
+++ b/Examples/macOS SwiftUI/EventParsing/EventParsing/EventParsingApp.swift
@@ -15,7 +15,7 @@ struct EventParsingApp: App {
         manufacturer: "MyCompany"
     )
     
-    @StateObject var midiHelper = MIDIHelper()
+    var midiHelper = MIDIHelper()
     
     init() {
         midiHelper.midiManager = midiManager


### PR DESCRIPTION
Running the SwiftUI versions of the “EndpointPickers” and “EventParsing” Example apps on macOS results in the following runtime issue being reported in Xcode 14.2 (14C18), macOS: 13.1 (22C65).

_"EndpointPickers[4226:63591] [SwiftUI] Accessing StateObject's object without being installed on a View. This will create a new instance each time."_

Additionally, upon launch the "MIDI In Connection" and "MIDI Out Connection" popups in the "EndpointPickers" app don't correctly reflect the available endpoints on the system.

The issue is that in both Example apps 'midiHelper' is defined as a @StateObject property wrapper which should only be used for an ObservableObject created within a SwiftUI view (and only if that view created the instance). In this case MIDIHelper is being created within the App object not within a SwiftUI View.

The solution appears to be to simply remove the '@StateObject':

-    @StateObject var midiHelper = MIDIHelper()
+    var midiHelper = MIDIHelper()
