### PR TITLE
Use the index of an event in its containing array as the id for each …

### DIFF
--- a/Examples/iOS SwiftUI/EndpointPickers/EndpointPickers/ContentView.swift
+++ b/Examples/iOS SwiftUI/EndpointPickers/EndpointPickers/ContentView.swift
@@ -105,10 +105,13 @@ struct ContentView: View {
                 }
     
                 Section(header: Text("Received Events")) {
-                    List(midiHelper.receivedEvents.reversed(), id: \.self) {
-                        Text($0.description)
-                            .foregroundColor(color(for: $0))
+                    let events = midiHelper.receivedEvents.reversed()
+                    
+                    List(events.indices, id: \.self) { index in
+                        Text(events[index].description)
+                        .foregroundColor(color(for: events[index]))
                     }
+
                 }
             }
             .navigationBarTitle("Endpoint Pickers")

--- a/Examples/macOS SwiftUI/EndpointPickers/EndpointPickers/ContentView.swift
+++ b/Examples/macOS SwiftUI/EndpointPickers/EndpointPickers/ContentView.swift
@@ -122,9 +122,11 @@ struct ContentView: View {
             .padding(5)
     
             GroupBox(label: Text("Received Events")) {
-                List(midiHelper.receivedEvents.reversed(), id: \.self) {
-                    Text($0.description)
-                        .foregroundColor(color(for: $0))
+                let events = midiHelper.receivedEvents.reversed()
+                
+                List(events.indices, id: \.self) { index in
+                    Text(events[index].description)
+                    .foregroundColor(color(for: events[index]))
                 }
             }
         }
@@ -151,3 +153,4 @@ struct ContentView: View {
         }
     }
 }
+


### PR DESCRIPTION
Inputting the same midi event (e.g. pressing the same key) into the "EndpointPickers" Example app (macOS & iOS) results in the following warning being posted to the console:

_ForEach<ReversedCollection<Array<MIDIEvent>>, MIDIEvent, Text>: the ID noteOff(36 (C1)), midi1(64)/midi2(32768), chan: 0x0, group: 0x0) occurs multiple times within the collection, this will give undefined results!x_

Issue is that identical MIDIEvent's have the same id. In proposed fix we use the event's index in its containing array as the unique ID.
