### PR TITLE
Feature: cocoapods

### DIFF
--- a/MIDIKit.podspec
+++ b/MIDIKit.podspec
@@ -1,0 +1,61 @@
+Pod::Spec.new do |spec|
+  	spec.name             = 'MIDIKit'
+  	spec.version          = '0.9.4'
+  	spec.summary          = 'An elegant and modern CoreMIDI wrapper in pure Swift supporting MIDI 1.0 and MIDI 2.0.'
+  	spec.homepage         = 'https://github.com/orchetect/MIDIKit'
+  	spec.license          = { :type => 'MIT', :file => 'LICENSE' }
+  	spec.author           = { 'orchetect' => 'https://github.com/orchetect' }
+  	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
+  	spec.swift_version = '5.7'
+    spec.frameworks = 'CoreMIDI'  
+    #spec.platform = :osx
+
+    spec.tvos.deployment_target = '11.0'
+    spec.ios.deployment_target = '11.0'
+    spec.macos.deployment_target = '10.13'
+
+    spec.default_subspec = 'Main'
+
+    spec.subspec 'Main' do |subspec|
+    	subspec.source_files = 'Sources/MIDIKit/**/*'
+    	subspec.dependency 'MIDIKitCore'
+    	subspec.dependency 'MIDIKitIO'
+    	subspec.dependency 'MIDIKitControlSurfaces'
+    	subspec.dependency 'MIDIKitSMF'
+    	subspec.dependency 'MIDIKitSync'
+    	subspec.dependency 'MIDIKitUI'
+  	end
+
+  	spec.subspec 'MIDIKitCore' do |subspec|
+    	subspec.source_files = 'Sources/MIDIKitCore/**/*'
+    	subspec.dependency 'MIDIKitInternals'
+  	end
+
+  	spec.subspec 'MIDIKitIO' do |subspec|
+    	subspec.source_files = 'Sources/MIDIKitIO/**/*'
+    	subspec.dependency 'MIDIKitCore'
+  	end
+
+  	spec.subspec 'MIDIKitControlSurfaces' do |subspec|
+    	subspec.source_files = 'Sources/MIDIKitControlSurfaces/**/*'
+    	subspec.dependency 'MIDIKitCore'
+  	end
+
+  	spec.subspec 'MIDIKitSMF' do |subspec|
+    	subspec.source_files = 'Sources/MIDIKitSMF/**/*'
+    	subspec.dependency 'MIDIKitCore'
+    	subspec.dependency 'TimecodeKit'
+  	end
+
+  	spec.subspec 'MIDIKitSync' do |subspec|
+    	subspec.source_files = 'Sources/MIDIKitSync/**/*'
+    	subspec.dependency 'MIDIKitCore'
+    	subspec.dependency 'TimecodeKit'
+  	end
+
+  	spec.subspec 'MIDIKitUI' do |subspec|
+    	subspec.source_files = 'Sources/MIDIKitUI/**/*'
+    	subspec.dependency 'MIDIKitIO'
+  	end
+
+end

--- a/MIDIKit.podspec
+++ b/MIDIKit.podspec
@@ -14,48 +14,11 @@ Pod::Spec.new do |spec|
     spec.ios.deployment_target = '11.0'
     spec.macos.deployment_target = '10.13'
 
-    spec.default_subspec = 'Main'
-
-    spec.subspec 'Main' do |subspec|
-    	subspec.source_files = 'Sources/MIDIKit/**/*'
-    	subspec.dependency 'MIDIKitCore'
-    	subspec.dependency 'MIDIKitIO'
-    	subspec.dependency 'MIDIKitControlSurfaces'
-    	subspec.dependency 'MIDIKitSMF'
-    	subspec.dependency 'MIDIKitSync'
-    	subspec.dependency 'MIDIKitUI'
-  	end
-
-  	spec.subspec 'MIDIKitCore' do |subspec|
-    	subspec.source_files = 'Sources/MIDIKitCore/**/*'
-    	subspec.dependency 'MIDIKitInternals'
-  	end
-
-  	spec.subspec 'MIDIKitIO' do |subspec|
-    	subspec.source_files = 'Sources/MIDIKitIO/**/*'
-    	subspec.dependency 'MIDIKitCore'
-  	end
-
-  	spec.subspec 'MIDIKitControlSurfaces' do |subspec|
-    	subspec.source_files = 'Sources/MIDIKitControlSurfaces/**/*'
-    	subspec.dependency 'MIDIKitCore'
-  	end
-
-  	spec.subspec 'MIDIKitSMF' do |subspec|
-    	subspec.source_files = 'Sources/MIDIKitSMF/**/*'
-    	subspec.dependency 'MIDIKitCore'
-    	subspec.dependency 'TimecodeKit'
-  	end
-
-  	spec.subspec 'MIDIKitSync' do |subspec|
-    	subspec.source_files = 'Sources/MIDIKitSync/**/*'
-    	subspec.dependency 'MIDIKitCore'
-    	subspec.dependency 'TimecodeKit'
-  	end
-
-  	spec.subspec 'MIDIKitUI' do |subspec|
-    	subspec.source_files = 'Sources/MIDIKitUI/**/*'
-    	subspec.dependency 'MIDIKitIO'
-  	end
-
+    spec.source_files = 'Sources/MIDIKit/**/*'
+    spec.dependency 'MIDIKitCore'
+    spec.dependency 'MIDIKitIO'
+    spec.dependency 'MIDIKitControlSurfaces'
+    spec.dependency 'MIDIKitSMF'
+    spec.dependency 'MIDIKitSync'
+    spec.dependency 'MIDIKitUI'
 end

--- a/MIDIKit.podspec
+++ b/MIDIKit.podspec
@@ -8,8 +8,8 @@ Pod::Spec.new do |spec|
   	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
   	spec.swift_version = '5.7'
     spec.frameworks = 'CoreMIDI'  
-    #spec.platform = :osx
 
+	spec.static_framework = true
     spec.tvos.deployment_target = '11.0'
     spec.ios.deployment_target = '11.0'
     spec.macos.deployment_target = '10.13'

--- a/MIDIKitControlSurfaces.podspec
+++ b/MIDIKitControlSurfaces.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
   	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
   	spec.swift_version = '5.7'
     spec.frameworks = 'CoreMIDI'  
-    #spec.platform = :osx
+    spec.static_framework = true
 
     spec.tvos.deployment_target = '11.0'
     spec.ios.deployment_target = '11.0'

--- a/MIDIKitControlSurfaces.podspec
+++ b/MIDIKitControlSurfaces.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |spec|
+  	spec.name             = 'MIDIKitControlSurfaces'
+  	spec.version          = '0.9.4'
+  	spec.summary          = 'An elegant and modern CoreMIDI wrapper in pure Swift supporting MIDI 1.0 and MIDI 2.0.'
+  	spec.homepage         = 'https://github.com/orchetect/MIDIKit'
+  	spec.license          = { :type => 'MIT', :file => 'LICENSE' }
+  	spec.author           = { 'orchetect' => 'https://github.com/orchetect' }
+  	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
+  	spec.swift_version = '5.7'
+    spec.frameworks = 'CoreMIDI'  
+    #spec.platform = :osx
+
+    spec.tvos.deployment_target = '11.0'
+    spec.ios.deployment_target = '11.0'
+    spec.macos.deployment_target = '10.13'
+
+    spec.source_files = 'Sources/MIDIKitControlSurfaces/**/*'
+    spec.dependency 'MIDIKitCore'
+ }

--- a/MIDIKitControlSurfaces.podspec
+++ b/MIDIKitControlSurfaces.podspec
@@ -16,4 +16,4 @@ Pod::Spec.new do |spec|
 
     spec.source_files = 'Sources/MIDIKitControlSurfaces/**/*'
     spec.dependency 'MIDIKitCore'
- }
+end

--- a/MIDIKitCore.podspec
+++ b/MIDIKitCore.podspec
@@ -16,4 +16,4 @@ Pod::Spec.new do |spec|
 
     spec.source_files = 'Sources/MIDIKitCore/**/*'
     spec.dependency 'MIDIKitInternals'
- }
+end

--- a/MIDIKitCore.podspec
+++ b/MIDIKitCore.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   	spec.swift_version = '5.7'
     spec.frameworks = 'CoreMIDI'  
     #spec.platform = :osx
-
+    spec.static_framework = true	
     spec.tvos.deployment_target = '11.0'
     spec.ios.deployment_target = '11.0'
     spec.macos.deployment_target = '10.13'

--- a/MIDIKitCore.podspec
+++ b/MIDIKitCore.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |spec|
+  	spec.name             = 'MIDIKitCore'
+  	spec.version          = '0.9.4'
+  	spec.summary          = 'An elegant and modern CoreMIDI wrapper in pure Swift supporting MIDI 1.0 and MIDI 2.0.'
+  	spec.homepage         = 'https://github.com/orchetect/MIDIKit'
+  	spec.license          = { :type => 'MIT', :file => 'LICENSE' }
+  	spec.author           = { 'orchetect' => 'https://github.com/orchetect' }
+  	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
+  	spec.swift_version = '5.7'
+    spec.frameworks = 'CoreMIDI'  
+    #spec.platform = :osx
+
+    spec.tvos.deployment_target = '11.0'
+    spec.ios.deployment_target = '11.0'
+    spec.macos.deployment_target = '10.13'
+
+    spec.source_files = 'Sources/MIDIKitCore/**/*'
+    spec.dependency 'MIDIKitInternals'
+ }

--- a/MIDIKitIO.podspec
+++ b/MIDIKitIO.podspec
@@ -8,8 +8,8 @@ Pod::Spec.new do |spec|
   	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
   	spec.swift_version = '5.7'
     spec.frameworks = 'CoreMIDI'  
-    #spec.platform = :osx
-
+    
+    spec.static_framework = true	
     spec.tvos.deployment_target = '11.0'
     spec.ios.deployment_target = '11.0'
     spec.macos.deployment_target = '10.13'

--- a/MIDIKitIO.podspec
+++ b/MIDIKitIO.podspec
@@ -16,4 +16,4 @@ Pod::Spec.new do |spec|
 
     spec.source_files = 'Sources/MIDIKitIO/**/*'
     spec.dependency 'MIDIKitCore'
- }
+end

--- a/MIDIKitIO.podspec
+++ b/MIDIKitIO.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |spec|
+  	spec.name             = 'MIDIKitIO'
+  	spec.version          = '0.9.4'
+  	spec.summary          = 'An elegant and modern CoreMIDI wrapper in pure Swift supporting MIDI 1.0 and MIDI 2.0.'
+  	spec.homepage         = 'https://github.com/orchetect/MIDIKit'
+  	spec.license          = { :type => 'MIT', :file => 'LICENSE' }
+  	spec.author           = { 'orchetect' => 'https://github.com/orchetect' }
+  	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
+  	spec.swift_version = '5.7'
+    spec.frameworks = 'CoreMIDI'  
+    #spec.platform = :osx
+
+    spec.tvos.deployment_target = '11.0'
+    spec.ios.deployment_target = '11.0'
+    spec.macos.deployment_target = '10.13'
+
+    spec.source_files = 'Sources/MIDIKitIO/**/*'
+    spec.dependency 'MIDIKitCore'
+ }

--- a/MIDIKitInternals.podspec
+++ b/MIDIKitInternals.podspec
@@ -8,8 +8,7 @@ Pod::Spec.new do |spec|
   	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
   	spec.swift_version = '5.7'
     spec.frameworks = 'CoreMIDI'  
-    #spec.platform = :osx
-
+    spec.static_framework = true	
     spec.tvos.deployment_target = '11.0'
     spec.ios.deployment_target = '11.0'
     spec.macos.deployment_target = '10.13'

--- a/MIDIKitInternals.podspec
+++ b/MIDIKitInternals.podspec
@@ -15,4 +15,4 @@ Pod::Spec.new do |spec|
     spec.macos.deployment_target = '10.13'
 
     spec.source_files = 'Sources/MIDIKitInternals/**/*'
- }
+end

--- a/MIDIKitInternals.podspec
+++ b/MIDIKitInternals.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |spec|
+  	spec.name             = 'MIDIKitInternals'
+  	spec.version          = '0.9.4'
+  	spec.summary          = 'An elegant and modern CoreMIDI wrapper in pure Swift supporting MIDI 1.0 and MIDI 2.0.'
+  	spec.homepage         = 'https://github.com/orchetect/MIDIKit'
+  	spec.license          = { :type => 'MIT', :file => 'LICENSE' }
+  	spec.author           = { 'orchetect' => 'https://github.com/orchetect' }
+  	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
+  	spec.swift_version = '5.7'
+    spec.frameworks = 'CoreMIDI'  
+    #spec.platform = :osx
+
+    spec.tvos.deployment_target = '11.0'
+    spec.ios.deployment_target = '11.0'
+    spec.macos.deployment_target = '10.13'
+
+    spec.source_files = 'Sources/MIDIKitInternals/**/*'
+ }

--- a/MIDIKitSMF.podspec
+++ b/MIDIKitSMF.podspec
@@ -17,4 +17,4 @@ Pod::Spec.new do |spec|
     spec.source_files = 'Sources/MIDIKitSMF/**/*'
     spec.dependency 'MIDIKitCore'
     spec.dependency 'TimecodeKit'
- }
+ end

--- a/MIDIKitSMF.podspec
+++ b/MIDIKitSMF.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
   	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
   	spec.swift_version = '5.7'
     spec.frameworks = 'CoreMIDI'  
-    #spec.platform = :osx
+    spec.static_framework = true
 
     spec.tvos.deployment_target = '11.0'
     spec.ios.deployment_target = '11.0'

--- a/MIDIKitSMF.podspec
+++ b/MIDIKitSMF.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |spec|
+  	spec.name             = 'MIDIKitSMF'
+  	spec.version          = '0.9.4'
+  	spec.summary          = 'An elegant and modern CoreMIDI wrapper in pure Swift supporting MIDI 1.0 and MIDI 2.0.'
+  	spec.homepage         = 'https://github.com/orchetect/MIDIKit'
+  	spec.license          = { :type => 'MIT', :file => 'LICENSE' }
+  	spec.author           = { 'orchetect' => 'https://github.com/orchetect' }
+  	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
+  	spec.swift_version = '5.7'
+    spec.frameworks = 'CoreMIDI'  
+    #spec.platform = :osx
+
+    spec.tvos.deployment_target = '11.0'
+    spec.ios.deployment_target = '11.0'
+    spec.macos.deployment_target = '10.13'
+
+    spec.source_files = 'Sources/MIDIKitSMF/**/*'
+    spec.dependency 'MIDIKitCore'
+    spec.dependency 'TimecodeKit'
+ }

--- a/MIDIKitSync.podspec
+++ b/MIDIKitSync.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
   	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
   	spec.swift_version = '5.7'
     spec.frameworks = 'CoreMIDI'  
-    #spec.platform = :osx
+    spec.static_framework = true
 
     spec.tvos.deployment_target = '11.0'
     spec.ios.deployment_target = '11.0'

--- a/MIDIKitSync.podspec
+++ b/MIDIKitSync.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |spec|
+  	spec.name             = 'MIDIKitSync'
+  	spec.version          = '0.9.4'
+  	spec.summary          = 'An elegant and modern CoreMIDI wrapper in pure Swift supporting MIDI 1.0 and MIDI 2.0.'
+  	spec.homepage         = 'https://github.com/orchetect/MIDIKit'
+  	spec.license          = { :type => 'MIT', :file => 'LICENSE' }
+  	spec.author           = { 'orchetect' => 'https://github.com/orchetect' }
+  	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
+  	spec.swift_version = '5.7'
+    spec.frameworks = 'CoreMIDI'  
+    #spec.platform = :osx
+
+    spec.tvos.deployment_target = '11.0'
+    spec.ios.deployment_target = '11.0'
+    spec.macos.deployment_target = '10.13'
+
+    spec.source_files = 'Sources/MIDIKitSync/**/*'
+    spec.dependency 'MIDIKitCore'
+    spec.dependency 'TimecodeKit'
+ }

--- a/MIDIKitSync.podspec
+++ b/MIDIKitSync.podspec
@@ -17,4 +17,4 @@ Pod::Spec.new do |spec|
     spec.source_files = 'Sources/MIDIKitSync/**/*'
     spec.dependency 'MIDIKitCore'
     spec.dependency 'TimecodeKit'
- }
+ end

--- a/MIDIKitUI.podspec
+++ b/MIDIKitUI.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
   	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
   	spec.swift_version = '5.7'
     spec.frameworks = 'CoreMIDI'  
-    #spec.platform = :osx
+    spec.static_framework = true
 
     spec.tvos.deployment_target = '11.0'
     spec.ios.deployment_target = '11.0'

--- a/MIDIKitUI.podspec
+++ b/MIDIKitUI.podspec
@@ -16,4 +16,4 @@ Pod::Spec.new do |spec|
 
     spec.source_files = 'Sources/MIDIKitUI/**/*'
     spec.dependency 'MIDIKitIO'
- }
+ end

--- a/MIDIKitUI.podspec
+++ b/MIDIKitUI.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |spec|
+  	spec.name             = 'MIDIKitUI'
+  	spec.version          = '0.9.4'
+  	spec.summary          = 'An elegant and modern CoreMIDI wrapper in pure Swift supporting MIDI 1.0 and MIDI 2.0.'
+  	spec.homepage         = 'https://github.com/orchetect/MIDIKit'
+  	spec.license          = { :type => 'MIT', :file => 'LICENSE' }
+  	spec.author           = { 'orchetect' => 'https://github.com/orchetect' }
+  	spec.source           = { :git => 'https://github.com/orchetect/MIDIKit.git', :tag => spec.version.to_s }
+  	spec.swift_version = '5.7'
+    spec.frameworks = 'CoreMIDI'  
+    #spec.platform = :osx
+
+    spec.tvos.deployment_target = '11.0'
+    spec.ios.deployment_target = '11.0'
+    spec.macos.deployment_target = '10.13'
+
+    spec.source_files = 'Sources/MIDIKitUI/**/*'
+    spec.dependency 'MIDIKitIO'
+ }


### PR DESCRIPTION
Enables distribution of MIDIKit using Cocoapods.

Before official distribution on Cocoapods and for building on XCode from this repo, you must follow two steps in your XCode Project's `Podfile`:

1. Add this repo as a source (since the podspecs do not live on Cocoapods distribution yet)
2. Add each dependency to your podfile. For example:

```
#pod 'TimecodeKit', :git => 'https://github.com/arshiacont/TimecodeKit.git', :branch => 'feature/cocoapods'
  pod 'MIDIKitInternals', :git => 'https://github.com/arshiacont/MIDIKit.git', :branch => 'feature/cocoapods2'
  pod 'MIDIKitCore', :git => 'https://github.com/arshiacont/MIDIKit.git', :branch => 'feature/cocoapods2'
  pod 'MIDIKitIO', :git => 'https://github.com/arshiacont/MIDIKit.git', :branch => 'feature/cocoapods2'
```
then run `pod install` and open the workspace and compile!

The project as is, builds when following the two points above.

_Suggestions_
A. Once merged on MIDIKit main branch Cocoapod users can simply add pods by changing the Github address above!
B. To include only (example) `pod MIDIKitIO` without including other dependencies, all podspecs should be validated and submitted. This requires:
   * running `pod spec lint` on each podspec
   * using Semantic Versioning

If there is not much demand for Cocoapod support we might stay on step (A)