### PR TITLE
docs: fix some samples using outdated syntax

### DIFF
--- a/Sources/MIDIKit/MIDIKit.docc/MIDIKitIO/MIDIManager-Creating-Connections.md
+++ b/Sources/MIDIKit/MIDIKit.docc/MIDIKitIO/MIDIManager-Creating-Connections.md
@@ -22,7 +22,7 @@ Target endpoint(s) can be supplied upon managed connection creation, or added la
 
 ```swift
 try midiManager.addInputConnection(
-    toOutputs: [],
+    to: .none,
     tag: "InputConnection1",
     receiveHandler: .events { [weak self] events in
         // Note: this handler will be called on a background thread so be
@@ -71,7 +71,7 @@ Target endpoint(s) can be supplied upon managed connection creation, or added la
 
 ```swift
 try midiManager.addOutputConnection(
-    toInputs: [],
+    to: .none,
     tag: "OutputConnection1"
 )
 ```

--- a/Sources/MIDIKit/MIDIKit.docc/MIDIKitSMF/MIDIKitSMF-Getting-Started.md
+++ b/Sources/MIDIKit/MIDIKit.docc/MIDIKitSMF/MIDIKitSMF-Getting-Started.md
@@ -25,7 +25,7 @@ Tracks and events can be accessed once the file is successfully read.
 ```swift
 // using a file URL
 let url = URL() // replace with url to a MIDI file on disk
-let midiFile = try MIDI.File(midiFile: url)
+let midiFile = try MIDIFile(midiFile: url)
 print(midiFile.description) // prints human-readable debug output of the file
 
 // using a file path

--- a/Sources/MIDIKitIO/MIDIKitIO.docc/MIDIManager-Creating-Connections.md
+++ b/Sources/MIDIKitIO/MIDIKitIO.docc/MIDIManager-Creating-Connections.md
@@ -22,7 +22,7 @@ Target endpoint(s) can be supplied upon managed connection creation, or added la
 
 ```swift
 try midiManager.addInputConnection(
-    toOutputs: [],
+    to: .none,
     tag: "InputConnection1",
     receiveHandler: .events { [weak self] events in
         // Note: this handler will be called on a background thread so be

--- a/Sources/MIDIKitSMF/MIDIKitSMF.docc/MIDIKitSMF-Getting-Started.md
+++ b/Sources/MIDIKitSMF/MIDIKitSMF.docc/MIDIKitSMF-Getting-Started.md
@@ -25,7 +25,7 @@ Tracks and events can be accessed once the file is successfully read.
 ```swift
 // using a file URL
 let url = URL() // replace with url to a MIDI file on disk
-let midiFile = try MIDI.File(midiFile: url)
+let midiFile = try MIDIFile(midiFile: url)
 print(midiFile.description) // prints human-readable debug output of the file
 
 // using a file path


### PR DESCRIPTION
It looks like when the `toOutputs`/`toInputs` syntax was [changed](354e3dc6e4d2ad4d28aa43131a1a62fc71c8ca84) in 0.9.0, the sample projects were all updated but a few instances in the API documentation were missed.