### PR TITLE
Add Privacy Manifests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -69,6 +69,7 @@ let package = Package(
         .target(
             name: "MIDIKitInternals",
             dependencies: [],
+            resources: [.process("PrivacyInfo.xcprivacy")],
             swiftSettings: [.define("DEBUG", .when(configuration: .debug))]
         ),
         .target(
@@ -84,6 +85,7 @@ let package = Package(
                 .target(name: "MIDIKitInternals"),
                 .target(name: "MIDIKitCore")
             ],
+            resources: [.process("PrivacyInfo.xcprivacy")],
             swiftSettings: [.define("DEBUG", .when(configuration: .debug))]
         ),
         .target(

--- a/Sources/MIDIKitIO/PrivacyInfo.xcprivacy
+++ b/Sources/MIDIKitIO/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C56D.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/MIDIKitInternals/PrivacyInfo.xcprivacy
+++ b/Sources/MIDIKitInternals/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>8FFB.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds privacy manifests as required by Apple for Required Reason API. This was required for submissions to the App Store from May 1, 2024.

[Describing use of required reason API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)

I have added manifest to the following packages:

MIDIKitInternals

Using `mach_absolute_time()`.

> 8FFB.1
Declare this reason to access the system boot time to calculate absolute timestamps for events that occurred within your app, such as events related to the UIKit or AVFAudio frameworks.
Absolute timestamps for events that occurred within your app may be sent off-device. System boot time accessed for this reason, or any other information derived from system boot time, may not be sent off-device.

MIDIKitIO

Using `UserDefaults`.

> C56D.1
Declare this reason if your third-party SDK is providing a wrapper function around user defaults API(s) for the app to use, and you only access the user defaults APIs when the app calls your wrapper function. This reason may only be declared by third-party SDKs. This reason may not be declared if your third-party SDK was created primarily to wrap required reason API(s).
Information accessed for this reason, or any derived information, may not be used for your third-party SDK’s own purposes or sent off-device by your third-party SDK.

This is my assessment of how MIDIKit is using these APIs from reviewing the code. Please check that you are happy with this assessment.