### PR TITLE
Ensure Outputs are populated

### DIFF
--- a/Sources/MIDIKitIO/MIDIEndpoints/MIDIEndpoints.swift
+++ b/Sources/MIDIKitIO/MIDIEndpoints/MIDIEndpoints.swift
@@ -35,15 +35,15 @@ extension MIDIEndpoints {
         inputsOwned.removeAll(where: { fetched.inputsUnowned.contains($0) })
         self.inputsOwned = inputsOwned
         
-        inputsUnowned = fetched.inputsUnowned
+        self.inputsUnowned = fetched.inputsUnowned
         
         outputs = fetched.outputs
         
-        var outputsUnowned = outputs
-        outputsUnowned.removeAll(where: { fetched.outputsUnowned.contains($0) })
-        self.outputsUnowned = outputsUnowned
+        var outputsOwned = outputs
+        outputsOwned.removeAll(where: { fetched.outputsUnowned.contains($0) })
+        self.outputsOwned = outputsOwned
         
-        outputsUnowned = fetched.outputsUnowned
+        self.outputsUnowned = fetched.outputsUnowned
     }
 }
 


### PR DESCRIPTION
Unowned and Owned Outputs were not correctly assigned.

This resolves the issue and adds reference to `self` to help readability and prevent issues in the future.