### PR TITLE
Fix for code scanning alerts 1-12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: build
-
+permissions:
+  contents: read
+  
 on:
   push:
     branches: [main]

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: examples
 
 on:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,6 +1,6 @@
+name: examples
 permissions:
   contents: read
-name: examples
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/orchetect/MIDIKit/security/code-scanning/12](https://github.com/orchetect/MIDIKit/security/code-scanning/12)

To fix the issue, we will add an explicit `permissions` block at the root of the workflow to limit access to the `GITHUB_TOKEN`. Based on the context of the workflow, which involves building project files, it does not appear to require write permissions. As such, we will set `contents: read` to provide minimal read-only access. This ensures that the workflow adheres to the principle of least privilege.

This change will be made at the top level of the workflow, right after the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
