### PR TITLE
MIDI Manager Deadlock Fix

### DIFF
--- a/Sources/MIDIKitIO/MIDIInput/MIDIInput.swift
+++ b/Sources/MIDIKitIO/MIDIInput/MIDIInput.swift
@@ -139,12 +139,9 @@ extension MIDIInput {
                 manager.coreMIDIClientRef,
                 name as CFString,
                 &newPortRef,
-                { [weak self, weak queue = midiManager?.managementQueue] packetListPtr, srcConnRefCon in
+                { [weak receiveHandler = receiveHandler] packetListPtr, srcConnRefCon in
                     let packets = packetListPtr.packets(refCon: srcConnRefCon, refConKnown: false)
                     
-                    // we need to read the `receiveHandler` on the same queue that it was created on
-                    // to satisfy the thread sanitizer.
-                    let receiveHandler = queue?.sync { self?.receiveHandler }
                     receiveHandler?.packetListReceived(packets)
                 }
             )
@@ -162,13 +159,10 @@ extension MIDIInput {
                 name as CFString,
                 api.midiProtocol.coreMIDIProtocol,
                 &newPortRef,
-                { [weak self, weak queue = midiManager?.managementQueue] eventListPtr, srcConnRefCon in
+                { [weak receiveHandler = receiveHandler] eventListPtr, srcConnRefCon in
                     let packets = eventListPtr.packets(refCon: srcConnRefCon, refConKnown: false)
                     let midiProtocol = MIDIProtocolVersion(eventListPtr.pointee.protocol)
                     
-                    // we need to read the `receiveHandler` on the same queue that it was created on
-                    // to satisfy the thread sanitizer.
-                    let receiveHandler = queue?.sync { self?.receiveHandler }
                     receiveHandler?.eventListReceived(
                         packets,
                         protocol: midiProtocol

--- a/Sources/MIDIKitIO/MIDIManager/MIDIManager State.swift
+++ b/Sources/MIDIKitIO/MIDIManager/MIDIManager State.swift
@@ -40,16 +40,18 @@ extension MIDIManager {
             }
             assert(newCoreMIDIClientRef != MIDIClientRef())
             self.coreMIDIClientRef = newCoreMIDIClientRef
+            
+            // initial cache of endpoints
+            updateObjectsCache()
         }
-        
-        // initial cache of endpoints
-        updateObjectsCache()
     }
     
     private func internalNotificationHandler(_ internalNotif: MIDIIOInternalNotification) {
         switch internalNotif {
         case .setupChanged, .added, .removed, .propertyChanged:
-            updateObjectsCache()
+            managementQueue.async {
+                self.updateObjectsCache()
+            }
         default:
             break
         }

--- a/Sources/MIDIKitIO/MIDIManager/MIDIManager.swift
+++ b/Sources/MIDIKitIO/MIDIManager/MIDIManager.swift
@@ -175,10 +175,8 @@ public class MIDIManager: @unchecked Sendable { // forced to use @unchecked sinc
     
     /// Internal: updates cached properties for all objects.
     func updateObjectsCache() {
-        managementQueue.sync {
-            devices.updateCachedProperties()
-            endpoints.updateCachedProperties(manager: self)
-        }
+        self.devices.updateCachedProperties()
+        self.endpoints.updateCachedProperties(manager: self)
     }
 }
 


### PR DESCRIPTION
- `MIDIManager`: Fixed rare issue where internal deadlock could occur while creating an input or input connection and receiving MIDI at the exact same instant